### PR TITLE
Adding KEY_ENTER to list of keys

### DIFF
--- a/nodes/keys.js
+++ b/nodes/keys.js
@@ -1,6 +1,7 @@
 module.exports = [
   '',
   'KEY_MENU',
+  'KEY_ENTER',
   'KEY_UP',
   'KEY_DOWN',
   'KEY_LEFT',


### PR DESCRIPTION
I had to look around for a while before I figured out that `KEY_ENTER` is the enter-key via the API. I have tested it on a Samsung-tv, and it works perfectly.